### PR TITLE
removes nunjucks usage

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,6 +21,16 @@ switch (platform) {
 let image = fs.readFileSync(path);
 let stringImage = image.toString("base64");
 
+const sidebarBackground = {
+    default: '#2C2C2C',
+    success: '#7ecf2b',
+    notice: '#f0e137',
+    warning: '#ff9a1f',
+    danger: '#ff5631',
+    surprise: '#a896ff',
+    info: '#46c1e6',
+};
+
 //image URL https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/f484215b-4e9a-42b5-9feb-77c3dec3a385/d8uxy4w-26b7903c-cd55-456e-ab71-5899ba014a88.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwic3ViIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsImF1ZCI6WyJ1cm46c2VydmljZTpmaWxlLmRvd25sb2FkIl0sIm9iaiI6W1t7InBhdGgiOiIvZi9mNDg0MjE1Yi00ZTlhLTQyYjUtOWZlYi03N2MzZGVjM2EzODUvZDh1eHk0dy0yNmI3OTAzYy1jZDU1LTQ1NmUtYWI3MS01ODk5YmEwMTRhODgucG5nIn1dXX0.Y3ZWqsBk3DMzW1YBdIELPFQr4dzz3qa2dKx_qgPLDeM
 
 module.exports.themes = [{
@@ -72,15 +82,7 @@ module.exports.themes = [{
                 },
             },
             sidebar: {
-                background: {
-                    default: '#2C2C2C',
-                    success: '#7ecf2b',
-                    notice: '#f0e137',
-                    warning: '#ff9a1f',
-                    danger: '#ff5631',
-                    surprise: '#a896ff',
-                    info: '#46c1e6',
-                },
+                background: sidebarBackground,
                 foreground: {
                     default: '#e0e0e0',
                 },
@@ -112,13 +114,8 @@ module.exports.themes = [{
             },
             pane: {
                 background: {
+                    ...sidebarBackground,
                     default: '#292929',
-                    success: '{{ styles.sidebar.background.success }}',
-                    notice: '{{ styles.sidebar.background.notice }}',
-                    warning: '{{ styles.sidebar.background.warning }}',
-                    danger: '{{ styles.sidebar.background.danger }}',
-                    surprise: '{{ styles.sidebar.background.surprise }}',
-                    info: '{{ styles.sidebar.background.info }}',
                 },
                 foreground: {
                     default: '#e0e0e0',


### PR DESCRIPTION
Hi!

Thanks for making an Insomnia theme!

We're in process of making a change (https://github.com/Kong/insomnia/pull/4933) that removes nunjucks templating (because it's not needed). I went ahead and updated your theme for you to save you the time.

Please let me know if I can help in any way. :)

I wasn't able to test this because I'm not on a mac and I get "Unsupported platform!", but you can try this out at any time (including before release of the PR mentioned above).